### PR TITLE
chore: patch complex form object with script

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -98,6 +98,16 @@ jobs:
           find $(cat PACKAGE) -mindepth 1 ! -name 'py.typed' -delete
           java -jar openapi-generator-cli.jar generate -c openapitools.json
 
+      - name: Setup Python for post-generation fixes
+        if: inputs.version == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Fix filters serialization
+        if: inputs.version == ''
+        run: python fix_filters_serialization.py
+
       - name: Git Setup
         if: inputs.version == ''
         run: |

--- a/cloudbeds_fiscal_document/api/fiscal_documents_api.py
+++ b/cloudbeds_fiscal_document/api/fiscal_documents_api.py
@@ -5301,7 +5301,24 @@ class FiscalDocumentsApi:
             
         if filters is not None:
             
-            _query_params.append(('filters', filters))
+            # Custom form serialization for filters
+            if hasattr(filters, 'to_dict'):
+                filters_dict = filters.to_dict()
+                for key, value in filters_dict.items():
+                    if value is not None:
+                        if isinstance(value, list):
+                            for item in value:
+                                if hasattr(item, 'value'):  # Handle enums
+                                    _query_params.append((key, item.value))
+                                else:
+                                    _query_params.append((key, item))
+                        else:
+                            if hasattr(value, 'value'):  # Handle enums
+                                _query_params.append((key, value.value))
+                            else:
+                                _query_params.append((key, value))
+            else:
+                _query_params.append(('filters', filters))
             
         # process the header parameters
         if x_property_id is not None:

--- a/fix_filters_serialization.py
+++ b/fix_filters_serialization.py
@@ -1,0 +1,67 @@
+"""
+Post-generation script to fix filters serialization in the OpenAPI-generated Python client.
+This script automatically patches the getFiscalDocuments method to properly serialize
+the filters parameter as form data instead of URL-encoded query parameter.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+def fix_filters_serialization():
+    """Fix the filters serialization in the generated API client."""
+    
+    api_file = Path("cloudbeds_fiscal_document/api/fiscal_documents_api.py")
+    
+    if not api_file.exists():
+        print(f"Error: {api_file} not found")
+        return False
+    
+    print(f"Patching filters serialization in {api_file}...")
+    
+    # Read the current content
+    content = api_file.read_text()
+    
+    # Pattern to find the problematic filters serialization
+    old_pattern = r'(\s+if filters is not None:\s+\n\s+)(_query_params\.append\(\(\'filters\', filters\)\))'
+    
+    # New serialization logic
+    new_serialization = r'''\1# Custom form serialization for filters
+            if hasattr(filters, 'to_dict'):
+                filters_dict = filters.to_dict()
+                for key, value in filters_dict.items():
+                    if value is not None:
+                        if isinstance(value, list):
+                            for item in value:
+                                if hasattr(item, 'value'):  # Handle enums
+                                    _query_params.append((key, item.value))
+                                else:
+                                    _query_params.append((key, item))
+                        else:
+                            if hasattr(value, 'value'):  # Handle enums
+                                _query_params.append((key, value.value))
+                            else:
+                                _query_params.append((key, value))
+            else:
+                _query_params.append(('filters', filters))'''
+    
+    # Apply the fix
+    new_content = re.sub(old_pattern, new_serialization, content, flags=re.MULTILINE)
+    
+    # Check if the replacement was successful
+    if new_content == content:
+        print("No filters serialization pattern found to replace")
+        return True
+    
+    # Write the updated content back
+    api_file.write_text(new_content)
+    print("Successfully patched filters serialization!")
+    return True
+
+def main():
+    """Main function."""
+    success = fix_filters_serialization()
+    sys.exit(0 if success else 1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces a post-generation patch script to correct an issue where openapi-generator fails to properly serialize complex query filter objects `(style: form, explode: true)` for the Fiscal Document service API.

The Problem
We are using a complex object, FiscalDocumentFilters, as a query parameter defined with style: form and explode: true:

```YAML

- in: query
  name: filters
  schema:
    $ref: "#/components/schemas/FiscalDocumentFilters"
  style: form
  explode: true
```

According to the OpenAPI specification for this style, a filter object like `{ "ids": [1, 2] }` should be serialized in the URL query as: `?ids=1&ids=2`

However, a known limitation in the generator causes it to ignore this serialization rule. Instead, it generates a single, URL-encoded JSON string: `?filters={"ids":[1,2]}`

The target Fiscal Document service API does not accept this JSON format and expects the correctly exploded parameters.

The core OpenAPI specification itself is correct. When testing the endpoint directly via Swagger UI, the UI correctly serializes the request parameters as expected `(?ids=1&ids=2)`, and the API call succeeds. This confirms the issue lies entirely within the generated client code.

Since this is a generator limitation rather than a spec error, this PR implements a targeted patch. A script is now configured to run immediately after each code generation step. This script modifies the generated client methods responsible for the Fiscal Document filters, forcing them to serialize the filter object correctly according to the form / explode: true standard expected by the API.